### PR TITLE
Reassign actions for buttons on GPIO pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ We use [Ansible](https://docs.ansible.com) to automate the rest of the setup of 
 
 When Raspberry Pi OS is shut down and power is still suplied to the Raspberry Pi, the Mini PiTFT display will show the last image that was sent to it. If the green ACT light in the corner of the Raspberry Pi is off _and_ the link lights on the Raspberry Pi's Ethernet port are off, then Raspebrry Pi OS is halted. If this is the case, then unplug and re-plug the power to the Raspberry Pi to restart it.
 
-If Raspberry Pi is on and the display is frozen, then you can restart the program that drives the dispaly. To do this, carefully reach under the Raspberry Pi's cover with an insulating object and press the _uppermost_ of the two buttons on the Mini PiTFT to restart the display program.
+If Raspberry Pi is on and the display is frozen, then you can restart the program that drives the display. To do this, carefully reach under the Raspberry Pi's cover with an insulating object and press the _uppermost_ of the two buttons on the Mini PiTFT to restart the display program.
 
 ### One or more Kafka brokers are never in sync.
 

--- a/playbooks/pitft_buttons.yml
+++ b/playbooks/pitft_buttons.yml
@@ -48,7 +48,6 @@
         content: |
           GPIO_HOLD_TIME="5"
           GPIO_WHEN_HELD="poweroff"
-          GPIO_WHEN_PRESSED="systemctl restart gcndemo.service"
         dest: /etc/gpio/23
 
     - name: Restart GPIO23 service
@@ -60,7 +59,7 @@
     - name: Configure GPIO24
       ansible.builtin.copy:
         content: |
-          GPIO_WHEN_PRESSED="systemctl restart confluent-kafka.service"
+          GPIO_WHEN_PRESSED="systemctl restart gcndemo.service"
         dest: /etc/gpio/24
 
     - name: Restart GPIO24 service
@@ -78,11 +77,22 @@
         content: |
           GPIO_HOLD_TIME="5"
           GPIO_WHEN_HELD="poweroff"
-          GPIO_WHEN_RELEASED="systemctl restart gcndemo.service"
         dest: /etc/gpio/24
 
     - name: Restart GPIO24 service
       ansible.builtin.systemd_service:
         name: gpio@24.service
+        enabled: true
+        state: restarted
+
+    - name: Configure GPIO23
+      ansible.builtin.copy:
+        content: |
+          GPIO_WHEN_PRESSED="systemctl restart gcndemo.service"
+        dest: /etc/gpio/23
+
+    - name: Restart GPIO24 service
+      ansible.builtin.systemd_service:
+        name: gpio@23.service
         enabled: true
         state: restarted


### PR DESCRIPTION
Previously, holding down the top button for 5 seconds initiated shutdown, whereas pressing the button restarted the display program.

However, this was flaky, and often simply pressing the top button initiated the shutdown.

Now, the top button _only_ initiates shutdown and the bottom button _only_ restarts the display program.